### PR TITLE
Make library compatible with Tesla 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: elixir
-elixir: '1.5.2'
-otp_release: '20.1'
+elixir:
+  - '1.5.3'
+  - '1.6.4'
+otp_release: '20.3'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tesla.StatsD
 
-`Tesla.StatsD` is an instrumenting middleware for [tesla](https://github.com/teamon/tesla) 
+`Tesla.StatsD` is an instrumenting middleware for [tesla](https://github.com/teamon/tesla)
 HTTP client that submits metrics to StatsD (includes support for Datadog tags).
 
 Documentation can be found at [https://hexdocs.pm/tesla_statsd](https://hexdocs.pm/tesla_statsd).
@@ -23,6 +23,18 @@ Datadog StatsD agent.
 ## Installation
 
 The package can be installed by adding `tesla_statsd` to your list of dependencies in `mix.exs`:
+
+### Tesla 1.x
+
+```elixir
+def deps do
+  [
+    {:tesla_statsd, "~> 0.2.0"}
+  ]
+end
+```
+
+### Tesla 0.9
 
 ```elixir
 def deps do

--- a/lib/tesla_statsd.ex
+++ b/lib/tesla_statsd.ex
@@ -50,16 +50,17 @@ defmodule Tesla.StatsD do
     opts = opts || []
     start = System.monotonic_time()
 
-    try do
-      env = Tesla.run(env, next)
-      send_stats(env, elapsed_from(start), opts)
-      env
-    rescue
-      ex in Tesla.Error ->
-        stacktrace = System.stacktrace()
+    result = Tesla.run(env, next)
+
+    case result do
+      {:ok, env} ->
+        send_stats(env, elapsed_from(start), opts)
+
+      {:error, _reason} ->
         send_stats(%{env | status: 0}, elapsed_from(start), opts)
-        reraise ex, stacktrace
     end
+
+    result
   end
 
   defp send_stats(env, elapsed, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,11 @@ defmodule Tesla.StatsD.Mixfile do
       build_embedded: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      description: description()
+      description: description(),
+      docs: [
+        extras: ["README.md"],
+        main: "readme"
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Tesla.StatsD.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:tesla, "~> 0.9"},
+      {:tesla, "~> 1.0"},
       {:mox, "~> 0.3.1", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tesla.StatsD.Mixfile do
   def project do
     [
       app: :tesla_statsd,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
-  "mox": {:hex, :mox, "0.3.1", "2ab1dce006387a91fbe1e727ba468d3e0691eacfd4e2fc7308d53676ec335c46", [], [], "hexpm"},
-  "tesla": {:hex, :tesla, "0.9.0", "db5c86895b63e698bbc61d62b4fd32735112de80ed82dcceef3660679fed9324", [], [{:exjsx, ">= 0.1.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "mox": {:hex, :mox, "0.3.2", "3b9b8364fd4f28628139de701d97c636b27a8f925f57a8d5a1b85fbd620dad3a", [:mix], [], "hexpm"},
+  "tesla": {:hex, :tesla, "1.0.0", "94a9059456d51266f3d40b75ff6be3d18496072ce5ffaabad03d6c00f065cfd1", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+}

--- a/test/tesla_statsd_test.exs
+++ b/test/tesla_statsd_test.exs
@@ -47,11 +47,9 @@ defmodule Tesla.StatsDTest do
       :ok
     end)
 
-    Tesla.Mock.mock(fn _env -> raise %Tesla.Error{message: "connection error"} end)
+    Tesla.Mock.mock(fn env -> {:error, %Tesla.Error{env: env, reason: "connection error"}} end)
 
-    assert_raise Tesla.Error, fn ->
-      TestClient.new() |> TestClient.get("http://test-api/test")
-    end
+    assert {:error, %Tesla.Error{}} = TestClient.new() |> TestClient.get("http://test-api/test")
   end
 
   test "allows configuring metric name" do


### PR DESCRIPTION
There have been some breaking changes in Tesla 1.0 (see [1]).

I don't think it's worth to have latest version of `tesla-statsd`
be compatible with old Tesla, people who really need Tesla 0.9 can
use version 0.1.x.

[1] https://github.com/teamon/tesla/wiki/0.x-to-1.0-Migration-Guide