### PR TITLE
Change `Tesla.StatsD.Backend` to be compatible with Statix by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: elixir
 elixir:
-  - '1.5.3'
-  - '1.6.4'
-otp_release: '20.3'
+- '1.5.3'
+- '1.6.6'
+- '1.7.4'
+otp_release:
+- '20.3'
+- '21.0'
+matrix:
+  exclude:
+  - elixir: '1.5.3'
+    otp_release: '21.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.3.0]
+
+### Changed
+- `Tesla.StatsD.Backend` callback functions changed signature. Both `gauge/3` and `histogram/3`
+  now accept metric name as a first argument and metric value as a second (previously it was
+  the other way around).
+- Default backend changed to `Tesla.StatsD.Backend.ExStatsD`.
+
+### Added
+- `Tesla.StatsD.Backend.ExStatsD` backend to support `ExStatsD`.
+
+## [0.2.0]
+
+### Added
+- Support for Tesla 1.1.
+
+### Removed
+- Support for Tesla 0.x.
+
+## [0.1.1]
+
+### Changed
+- Elixir minimum version set to 1.4.
+
+## [0.1.0]
+
+Initial release
+
+[0.3.0]: https://github.com/salemove/tesla_statsd/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/salemove/tesla_statsd/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/salemove/tesla_statsd/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/salemove/tesla_statsd/tree/v0.1.0

--- a/lib/tesla_statsd.ex
+++ b/lib/tesla_statsd.ex
@@ -15,8 +15,9 @@ defmodule Tesla.StatsD do
 
   ## Configuration
 
-    * `:backend` - StatsD backend module. Defaults to `ExStatsD`. A backend must implement
-      `Tesla.StatsD.Backend` behaviour.
+    * `:backend` - StatsD backend module. Defaults to `Tesla.StatsD.Backend.ExStatsD`.
+      A backend must implement `Tesla.StatsD.Backend` behaviour. `Statix` backends are
+      supported by default, just provide a module name that uses `Statix` (`use Statix`).
     * `:metric` - Metric name. Can be ether string or function `(Tesla.Env.t -> String.t)`.
     * `:metric_type` - Metric type. Can be `:histogram` (default) or `:gauge`. See
       [Datadog documentation](https://docs.datadoghq.com/guides/dogstatsd/#data-types).
@@ -28,7 +29,10 @@ defmodule Tesla.StatsD do
       defmodule AccountsClient do
         use Tesla
 
-        plug Tesla.StatsD, metric: "external.request", tags: ["service:accounts"]
+        plug Tesla.StatsD,
+          metric: "external.request",
+          tags: ["service:accounts"],
+          backend: MyApp.Statix
       end
   """
 
@@ -37,7 +41,7 @@ defmodule Tesla.StatsD do
   @default_options [
     metric: "http.request",
     metric_type: :histogram,
-    backend: ExStatsD,
+    backend: Tesla.StatsD.Backend.ExStatsD,
     sample_rate: 1,
     tags: []
   ]
@@ -73,8 +77,8 @@ defmodule Tesla.StatsD do
     metric_type = Keyword.fetch!(opts, :metric_type)
 
     apply(backend, metric_type, [
-      elapsed,
       metric,
+      elapsed,
       [sample_rate: rate, tags: build_tags(env, tags)]
     ])
   end

--- a/lib/tesla_statsd/backend.ex
+++ b/lib/tesla_statsd/backend.ex
@@ -2,8 +2,7 @@ defmodule Tesla.StatsD.Backend do
   @moduledoc """
   A behaviour for StatsD backend.
 
-  [ExStatsD](https://github.com/CargoSense/ex_statsd) is supported
-  out of box.
+  [Statix](https://github.com/lexmag/statix) is supported out of box.
   """
 
   @type metric :: String.t()
@@ -13,10 +12,10 @@ defmodule Tesla.StatsD.Backend do
   @doc """
   Record a gauge entry
   """
-  @callback gauge(amount, metric, options) :: any
+  @callback gauge(metric, amount, options) :: any
 
   @doc """
   Record a histogram value
   """
-  @callback histogram(amount, metric, options) :: any
+  @callback histogram(metric, amount, options) :: any
 end

--- a/lib/tesla_statsd/backend/ex_statsd.ex
+++ b/lib/tesla_statsd/backend/ex_statsd.ex
@@ -1,0 +1,17 @@
+defmodule Tesla.StatsD.Backend.ExStatsD do
+  @moduledoc """
+  [ExStatsD](https://github.com/CargoSense/ex_statsd) backend for `Tesla.StatsD`.
+  """
+
+  @behaviour Tesla.StatsD.Backend
+
+  @impl true
+  def gauge(metric, amount, options) do
+    ExStatsD.gauge(amount, metric, options)
+  end
+
+  @impl true
+  def histogram(metric, amount, options) do
+    ExStatsD.histogram(amount, metric, options)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tesla.StatsD.Mixfile do
   def project do
     [
       app: :tesla_statsd,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,8 @@ defmodule Tesla.StatsD.Mixfile do
   defp deps do
     [
       {:tesla, "~> 1.0"},
+      {:ex_statsd, "~> 0.5", optional: true},
+      {:statix, "~> 1.0", optional: true},
       {:mox, "~> 0.3.1", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_statsd": {:hex, :ex_statsd, "0.5.3", "e86dd97e25dbc80786e7d22b3c5537f2052a7e12daaaa7e6f2b9c34d03dbbd44", [:mix], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mox": {:hex, :mox, "0.3.2", "3b9b8364fd4f28628139de701d97c636b27a8f925f57a8d5a1b85fbd620dad3a", [:mix], [], "hexpm"},
+  "statix": {:hex, :statix, "1.1.0", "af9a4586c5cd58f879e0595f06a4790878715de5b8f75f6346693aaa38da2424", [:mix], [], "hexpm"},
   "tesla": {:hex, :tesla, "1.0.0", "94a9059456d51266f3d40b75ff6be3d18496072ce5ffaabad03d6c00f065cfd1", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
 }

--- a/test/tesla_statsd_test.exs
+++ b/test/tesla_statsd_test.exs
@@ -25,7 +25,7 @@ defmodule Tesla.StatsDTest do
   end
 
   test "sends stats for successful requests" do
-    expect(StatsMock, :histogram, fn _elapsed, metric, options ->
+    expect(StatsMock, :histogram, fn metric, _elapsed, options ->
       assert metric == "http.request"
       assert "http_host:test-api" in options[:tags]
       assert "http_status:200" in options[:tags]
@@ -38,7 +38,7 @@ defmodule Tesla.StatsDTest do
   end
 
   test "sends http_status:0 for failed requests" do
-    expect(StatsMock, :histogram, fn _elapsed, metric, options ->
+    expect(StatsMock, :histogram, fn metric, _elapsed, options ->
       assert metric == "http.request"
       assert "http_host:test-api" in options[:tags]
       assert "http_status:0" in options[:tags]
@@ -55,7 +55,7 @@ defmodule Tesla.StatsDTest do
   test "allows configuring metric name" do
     metric = "foo"
 
-    expect(StatsMock, :histogram, fn _elapsed, ^metric, _options -> :ok end)
+    expect(StatsMock, :histogram, fn ^metric, _elapsed, _options -> :ok end)
 
     TestClient.new(metric: metric) |> TestClient.get("http://test-api/test")
   end
@@ -63,7 +63,7 @@ defmodule Tesla.StatsDTest do
   test "allows configuring metric name with function" do
     metric = fn env -> env.url end
 
-    expect(StatsMock, :histogram, fn _elapsed, "http://test-api/test", _options -> :ok end)
+    expect(StatsMock, :histogram, fn "http://test-api/test", _elapsed, _options -> :ok end)
 
     TestClient.new(metric: metric) |> TestClient.get("http://test-api/test")
   end
@@ -71,7 +71,7 @@ defmodule Tesla.StatsDTest do
   test "allows configuring tags per request" do
     tags = ["service:test", "env:test"]
 
-    expect(StatsMock, :histogram, fn _elapsed, _metric, options ->
+    expect(StatsMock, :histogram, fn _metric, _elapsed, options ->
       assert "http_host:test-api" in options[:tags]
       assert "http_status:200" in options[:tags]
       assert "http_status_family:2xx" in options[:tags]
@@ -87,7 +87,7 @@ defmodule Tesla.StatsDTest do
   test "allows configuring tags per request with function" do
     tags = fn env -> ["url:#{env.url}"] end
 
-    expect(StatsMock, :histogram, fn _elapsed, _metric, options ->
+    expect(StatsMock, :histogram, fn _metric, _elapsed, options ->
       assert "http_host:test-api" in options[:tags]
       assert "http_status:200" in options[:tags]
       assert "http_status_family:2xx" in options[:tags]
@@ -100,7 +100,7 @@ defmodule Tesla.StatsDTest do
   end
 
   test "allows configuring submission type" do
-    expect(StatsMock, :gauge, fn _elapsed, _metric, options ->
+    expect(StatsMock, :gauge, fn _metric, _elapsed, options ->
       assert "http_host:test-api" in options[:tags]
       assert "http_status:200" in options[:tags]
       assert "http_status_family:2xx" in options[:tags]


### PR DESCRIPTION
`ExStatsD` is deprecated and it is recommended to use `Statix` instead.
Make behaviour compatible with Statix and add compatibility layer for
ExStatsD.