### PR TITLE
Use singular to_unit in System.convert_time_unit/3

### DIFF
--- a/lib/tesla_statsd.ex
+++ b/lib/tesla_statsd.ex
@@ -113,7 +113,7 @@ defmodule Tesla.StatsD do
   end
 
   defp elapsed_from(start) do
-    System.convert_time_unit(System.monotonic_time() - start, :native, :milliseconds)
+    System.convert_time_unit(System.monotonic_time() - start, :native, :millisecond)
   end
 
   defp normalize_metric(metric, env) when is_function(metric) do


### PR DESCRIPTION
Plural to_unit is deprecated in newer elixir versions.