### PR TITLE
Change default sample rate from 1 to 1.0 to fix Statix integration

### DIFF
--- a/lib/tesla_statsd.ex
+++ b/lib/tesla_statsd.ex
@@ -42,7 +42,7 @@ defmodule Tesla.StatsD do
     metric: "http.request",
     metric_type: :histogram,
     backend: Tesla.StatsD.Backend.ExStatsD,
-    sample_rate: 1,
+    sample_rate: 1.0,
     tags: []
   ]
 


### PR DESCRIPTION
Statix.Packet.set_option/3 requires the sample rate to be a float. 
See: https://github.com/lexmag/statix/blob/30f5b2704470a5a43c0b1a98312b02c102d6e6ec/lib/statix/packet.ex#L52

Currently the default sample rate value in tesla_statsd is set to an int.
See: https://github.com/salemove/tesla_statsd/blob/be53de4bfdae0b7a9dc1de3ea5efc782bd3f0fd4/lib/tesla_statsd.ex#L45

This result in the following error:

```
[error] Process #PID<0.861.0> raised an exception
** (FunctionClauseError) no function clause matching in Statix.Packet.set_option/3
    (statix) lib/statix/packet.ex:48: Statix.Packet.set_option([<<1, 31, 189, 127, 0, 0, 1>>, "example", 58, "119", 124, "h"], :sample_rate, 1)
    (statix) lib/statix/packet.ex:32: Statix.Packet.build/5
    (statix) lib/statix/conn.ex:29: Statix.Conn.transmit/5
    (tesla_statsd) lib/tesla_statsd.ex:61: Tesla.StatsD.call/3
    (stdlib) timer.erl:197: :timer.tc/3
    (tesla) lib/tesla/middleware/logger.ex:123: Tesla.Middleware.Logger.call/3
    (tesla) lib/tesla/middleware/json.ex:52: Tesla.Middleware.JSON.call/3
```

Changing the default value to `1.0` resolves the issue and all the tests continue to pass. 

I can maybe add a breaking test to prove the integer value breaks but I don't have time to do that right now. I'm also not sure if this test actually makes sense.