### PR TITLE
Add `Noop` backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  elixir:
+    name: OTP ${{matrix.pair.otp_version}} / Elixir ${{matrix.pair.elixir}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - pair:
+              elixir: '1.11'
+              otp: '23.0'
+          - pair:
+              elixir: '1.12'
+              otp: '24.0'
+          - pair:
+              elixir: '1.13'
+              otp: '24.0'
+            lint: lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-
+
+      - name: Run mix deps.get
+        run: mix deps.get
+
+      - name: Run mix format
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - name: Run mix deps.compile
+        run: mix deps.compile
+
+      - name: Run mix compile
+        run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+
+      - name: Run mix test
+        run: mix test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish Package
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Publish package to hex.pm
+        uses: wesleimp/action-publish-hex@ae719f0fead451221d2ca0127c0aae70c5f90b4c
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: elixir
-elixir:
-- '1.8.2'
-- '1.9.2'
-otp_release:
-- '21.3'
-- '22.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add `Noop` backend
+
 ## [0.3.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 - Add `Noop` backend
 
@@ -48,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release
 
+[0.4.0]: https://github.com/salemove/tesla_statsd/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/salemove/tesla_statsd/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/salemove/tesla_statsd/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/salemove/tesla_statsd/compare/v0.1.2...v0.2.0

--- a/lib/tesla_statsd/backend/noop.ex
+++ b/lib/tesla_statsd/backend/noop.ex
@@ -1,0 +1,17 @@
+defmodule Tesla.StatsD.Backend.Noop do
+  @moduledoc """
+  Backend that doesn't actually record any statistics. This can be useful in
+  test environments if you want to disable metrics without actually removing
+  the middleware.
+  """
+
+  @behaviour Tesla.StatsD.Backend
+
+  @impl true
+  def gauge(_metric, _amount, _options) do
+  end
+
+  @impl true
+  def histogram(_metric, _amount, _options) do
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tesla.StatsD.Mixfile do
   def project do
     [
       app: :tesla_statsd,
-      version: "0.3.2",
+      version: "0.4.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Backend that doesn't actually record any statistics. This can be useful in
test environments if you want to disable metrics without actually removing
the middleware.