### PR TITLE
Assign codeowners to tm-inf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-inf


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-inf as codeowners.

This is reassigned from https://github.com/salemove/tesla_statsd/pull/10 (changed branch name to match team name)